### PR TITLE
Update the way we add RabbitMQ repository

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,10 +1,7 @@
 ---
 
-- name: Add RabbitMQ key
-  apt_key: url=https://www.rabbitmq.com/rabbitmq-release-signing-key.asc state=present id=6026DFCA
-
 - name: Add RabbitMQ repository
-  apt_repository: repo='deb http://www.rabbitmq.com/debian/ testing main' update_cache=yes
+  shell: "curl -s https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.deb.sh | sudo bash"
 
 - name: Ensure RabbitMQ is installed
   apt: pkg=rabbitmq-server


### PR DESCRIPTION
Fixes https://github.com/Stouts/Stouts.rabbitmq/issues/9.

The old repository http://www.rabbitmq.com/debian is not available anymore.
The recommended way of installing RabbitMQ repositories is now by using their PackageCloud script.